### PR TITLE
Make crowdsourcing interface embeddable 

### DIFF
--- a/api-service/crowdflower-scripts/crowdflower.js
+++ b/api-service/crowdflower-scripts/crowdflower.js
@@ -1,0 +1,39 @@
+<iframe
+  src="https://crowdsource-demo-dot-wikidetox.appspot.com"
+  width="400"
+  height="600"
+  frameborder="0"
+  scrolling="no"
+  marginheight="0"
+  marginwidth="0"
+  ></iframe>
+
+<cml:hidden
+  default="test"
+  question-label="Sample text field:"
+  validates="required"
+  value="test"
+  name="question_comments">
+</cml:hidden>
+
+<cml:text label="Other concerns?"></cml:text>
+
+<script>
+  require(['jquery-noconflict'], function($) {
+  //Ensure MooTools is where it must be
+  Window.implement('$', function(el, nc){
+  return document.id(el, nc, this.document);
+  });
+
+  var $ = window.jQuery;
+
+  window.onmessage = function(e){
+  console.log('got message', e.data);
+  var data = JSON.parse(e.data);
+
+  console.log('data from iFrame', data);
+  $('.question_comments')[0].value = e.data;
+
+  };
+  });
+</script>

--- a/api-service/crowdflower-scripts/crowdflower.js
+++ b/api-service/crowdflower-scripts/crowdflower.js
@@ -1,12 +1,13 @@
 <iframe
-  src="https://crowdsource-demo-dot-wikidetox.appspot.com"
+  src="https://crowdsource-demo-dot-wikidetox.appspot.com/?embedded=true#{{job_client_id}}/{{question_id}}"
   width="400"
   height="600"
   frameborder="0"
   scrolling="no"
   marginheight="0"
   marginwidth="0"
-  ></iframe>
+  >
+</iframe>
 
 <cml:hidden
   default="test"
@@ -16,24 +17,20 @@
   name="question_comments">
 </cml:hidden>
 
-<cml:text label="Other concerns?"></cml:text>
-
 <script>
-  require(['jquery-noconflict'], function($) {
-  //Ensure MooTools is where it must be
-  Window.implement('$', function(el, nc){
-  return document.id(el, nc, this.document);
-  });
+require(['jquery-noconflict'], function($) {
+    //Ensure MooTools is where it must be
+    Window.implement('$', function(el, nc){
+	return document.id(el, nc, this.document);
+    });
 
-  var $ = window.jQuery;
+    var $ = window.jQuery;
 
-  window.onmessage = function(e){
-  console.log('got message', e.data);
-  var data = JSON.parse(e.data);
+    window.onmessage = function(e){
+	console.log('got message', e.data);
+	var data = JSON.parse(e.data);
 
-  console.log('data from iFrame', data);
-  $('.question_comments')[0].value = e.data;
-
-  };
-  });
+	$('.question_comments')[0].value = e.data;
+    };
+});
 </script>

--- a/api-service/crowdflower/README.md
+++ b/api-service/crowdflower/README.md
@@ -1,14 +1,15 @@
 # CrowdFlower Integration
 
-Steps to run a [CrowdFlower](http://www.crowdflower.com/) job using this interface.
+## Setup
+Steps to run a [CrowdFlower](http://www.crowdflower.com/) job using Crowd 9 interface.
 
-1. **Deploy the Crowd 9 app.** Follow [these steps](api-service#pre-requisits) to run a hosted instance of the Crowd 9 app.
+1. **Deploy the Crowd 9 app.** Follow [these steps](/api-service#pre-requisits) to run a hosted instance of the Crowd 9 app.
 
-2. **Create a new Crowd 9 job.** Add a new entry to the `client_jobs` table corresponding to the job you want to run. You can either use the admin [API](api-service/api-server#api) or add the data directly to the database. You can then use the API to add questions for the job.
+2. **Create a new Crowd 9 job.** Add a new entry to the `client_jobs` table corresponding to the job you want to run. You can either use the admin [API](/api-service/api-server#api) or add the data directly to the database. You can then use the API to add questions for the job.
 
-3. **Create a new CrowdFlower job.** In the Design tab, choose to use custom CSS/JS and paste in the code in the `crowdflower.js` file in this directory.
+3. **Create a new CrowdFlower job.** In the Design tab, choose to use custom CSS/JS and paste in the code in the `crowdflower.js` file in this directory. The code loads the Crowd 9 interface using an iFrame, listens for a message from the Crowd 9 app when an annotation is added and updates the value of a hidden CML input with the data from the annoation.
 
-4. **Add data.** Create a CSV with fields `question_id` and `client_job_key`. The `question_id` should correspond to the unique ID for each qustion in your job that you want to annotate. The `client_job_key` should correspond to the job in the `client_jobs` table.
+4. **Add data.** Create a CSV with fields `question_id` and `client_job_key`. The `question_id` should correspond to the unique ID for each question in your job that you want to annotate. The `client_job_key` should correspond to the job in the `client_jobs` table.
 
 Your data should look something like this:
 
@@ -21,7 +22,12 @@ question_id,client_job_key
 ...
 ```
 
-Now you're ready to launch the job! You can check that it's working by looking at the CrowdFlower preview and checking that the annotation you add are showing up in the `answers` table in Spanner. You can also launch the job without openning it up for external users. You will get a sharable link to test the job and can validate the full data flow. To do this, go to the Launch tab, and in Settings, uncheck the External checkbox under the Contributors section.
+You are now ready to launch the job!
 
-### Potential Issues
-* There is a unique constraint in the `answers` table that doesn't allow the same user to annotate the same question more than once. As a result, you may get 500 errors from `/api/answer/1k-demo-ptoxic` while testing.
+## Validation
+There are a few ways to validate that your job is set up correctly. The easiest way is to use the CrowdFlower preview feature and check that the annotation you make are showing up in the `answers` table in Spanner.
+
+To validate the end-to-end data flow in a near production environment, you can launch the job without openning it up for external users. You will get a sharable link to test the job which will function just like a regular CrowdFlower job. To do this, go to the Launch tab, and in Settings, uncheck the External checkbox under the Contributors section. Then launch the job for a handful of rows. You can use the sharable link to run through the job and verify that the annotated data is appearing in the CrowdFlower interface.
+
+## Potential Issues
+* There is a unique constraint in the `answers` table that doesn't allow the same user to annotate the same question more than once. As a result, you may get 500 errors from `/api/answer/1k-demo-ptoxic` while testing. You can fix this by deleting test answers from the database, just don't delete real data!

--- a/api-service/crowdflower/README.md
+++ b/api-service/crowdflower/README.md
@@ -1,0 +1,27 @@
+# CrowdFlower Integration
+
+Steps to run a [CrowdFlower](http://www.crowdflower.com/) job using this interface.
+
+1. **Deploy the Crowd 9 app.** Follow [these steps](api-service#pre-requisits) to run a hosted instance of the Crowd 9 app.
+
+2. **Create a new Crowd 9 job.** Add a new entry to the `client_jobs` table corresponding to the job you want to run. You can either use the admin [API](api-service/api-server#api) or add the data directly to the database. You can then use the API to add questions for the job.
+
+3. **Create a new CrowdFlower job.** In the Design tab, choose to use custom CSS/JS and paste in the code in the `crowdflower.js` file in this directory.
+
+4. **Add data.** Create a CSV with fields `question_id` and `client_job_key`. The `question_id` should correspond to the unique ID for each qustion in your job that you want to annotate. The `client_job_key` should correspond to the job in the `client_jobs` table.
+
+Your data should look something like this:
+
+```
+question_id,client_job_key
+004ba3a74c7c5a1147aab625f0f705d4955df2d229d39c123332fe4893c44072,1k-demo-ptoxic
+0076d1e1b9815a53ade444d4a69f72de72fca05cb356305ab32841cc4c88e61e,1k-demo-ptoxic
+0089f96a9762963cba9e00dffecfd1ccd8a97749b1d9df286ecf7e1de0366102,1k-demo-ptoxic
+0094596235a5f9288d388f1a649db5190a1212a16a759d04db5c84fea239bf59,1k-demo-ptoxic
+...
+```
+
+Now you're ready to launch the job! You can check that it's working by looking at the CrowdFlower preview and checking that the annotation you add are showing up in the `answers` table in Spanner. You can also launch the job without openning it up for external users. You will get a sharable link to test the job and can validate the full data flow. To do this, go to the Launch tab, and in Settings, uncheck the External checkbox under the Contributors section.
+
+### Potential Issues
+* There is a unique constraint in the `answers` table that doesn't allow the same user to annotate the same question more than once. As a result, you may get 500 errors from `/api/answer/1k-demo-ptoxic` while testing.

--- a/api-service/crowdflower/crowdflower.js
+++ b/api-service/crowdflower/crowdflower.js
@@ -1,7 +1,7 @@
 <iframe
-  src="https://crowdsource-demo-dot-wikidetox.appspot.com/?embedded=true#{{job_client_id}}/{{question_id}}"
+  src="https://crowdsource-demo-dot-wikidetox.appspot.com/?embedded=true#{{client_job_key}}/{{question_id}}"
   width="400"
-  height="600"
+  height="425"
   frameborder="0"
   scrolling="no"
   marginheight="0"

--- a/api-service/crowdflower/crowdflower.js
+++ b/api-service/crowdflower/crowdflower.js
@@ -17,20 +17,22 @@
   name="question_comments">
 </cml:hidden>
 
-<script>
-require(['jquery-noconflict'], function($) {
+  <script>
+  // JQuery include copied from CrowdFlower documentation
+  require(['jquery-noconflict'], function($) {
     //Ensure MooTools is where it must be
     Window.implement('$', function(el, nc){
-	return document.id(el, nc, this.document);
+      return document.id(el, nc, this.document);
     });
 
     var $ = window.jQuery;
 
     window.onmessage = function(e){
-	console.log('got message', e.data);
-	var data = JSON.parse(e.data);
+      console.log('got message', e.data);
+      var data = JSON.parse(e.data);
 
-	$('.question_comments')[0].value = e.data;
+      // TODO: add function to validate data
+      $('.question_comments')[0].value = e.data;
     };
-});
+  });
 </script>

--- a/api-service/webapp-demo/README.md
+++ b/api-service/webapp-demo/README.md
@@ -8,6 +8,8 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 Run `ng serve:dev` for a dev server backed by a localhost proxy to port 8080 for the API server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
+By default, the app will load a random question from the specified job.You can request a particular question in the hash, `http://localhost:4200/#{clientJobKey}/{questionId}`.
+
 ## Code scaffolding
 
 Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.

--- a/api-service/webapp-demo/README.md
+++ b/api-service/webapp-demo/README.md
@@ -8,7 +8,7 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 Run `ng serve:dev` for a dev server backed by a localhost proxy to port 8080 for the API server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
-By default, the app will load a random question from the specified job.You can request a particular question in the hash, `http://localhost:4200/#{clientJobKey}/{questionId}`.
+By default, the app will load a random question from the specified job. You can request a particular question in the hash, `http://localhost:4200/#{clientJobKey}/{questionId}`.
 
 ## Code scaffolding
 

--- a/api-service/webapp-demo/src/app/app.component.html
+++ b/api-service/webapp-demo/src/app/app.component.html
@@ -2,7 +2,7 @@
 <h1>Conversation AI Crowdsourcing Demo</h1>
 
 <div class="counts" *ngIf="notEmbedded">
-    <div>my worker id: {{userNonce}}</div>
+  <div>my worker id: {{userNonce}}</div>
   <div>local_sent_count: {{local_sent_count}}</div>
   <div>training_answer_count: {{training_answer_count}}</div>
   <div>user_mean_score: {{user_mean_score}}</div>

--- a/api-service/webapp-demo/src/app/app.component.html
+++ b/api-service/webapp-demo/src/app/app.component.html
@@ -1,8 +1,8 @@
 <!--The content below is only a placeholder and can be replaced.-->
 <h1>Conversation AI Crowdsourcing Demo</h1>
 
-<div class="counts">
-  <div>my worker id: {{userNonce}}</div>
+<div class="counts" *ngIf="notEmbedded">
+    <div>my worker id: {{userNonce}}</div>
   <div>local_sent_count: {{local_sent_count}}</div>
   <div>training_answer_count: {{training_answer_count}}</div>
   <div>user_mean_score: {{user_mean_score}}</div>
@@ -17,7 +17,7 @@
 </div>
 
 <div *ngIf="question">
-  <div class="id">{{question.id}}</div>
+  <div class="id" *ngIf="notEmbedded">{{question.id}}</div>
   <div class="text-header">Comment to rate:</div>
   <div class="text">{{question.text}}</div>
 

--- a/api-service/webapp-demo/src/app/app.component.ts
+++ b/api-service/webapp-demo/src/app/app.component.ts
@@ -31,6 +31,9 @@ interface JobQualitySummary {
   toanswer_mean_score: number;
 }
 
+// Constants for data collection
+const YES = 'Yes';
+const NO = 'No';
 
 @Component({
   selector: 'app-root',
@@ -200,12 +203,10 @@ export class AppComponent implements OnInit {
       answerPath += '/' + this.customClientJobKey;
     }
 
-    const yesEnglish = 'Yes';
-    const noEnglish = 'No';
     const answer = {
       questionId: this.questionId,
       userNonce: this.userNonce,
-      readableAndInEnglish: this.readableAndInEnglish ? yesEnglish: noEnglish,
+      readableAndInEnglish: this.readableAndInEnglish ? YES: NO,
       toxic: this.toxicityAnswer,
       obscene: this.obsceneAnswer,
       insult: this.insultAnswer,

--- a/api-service/webapp-demo/src/app/app.component.ts
+++ b/api-service/webapp-demo/src/app/app.component.ts
@@ -42,6 +42,7 @@ export class AppComponent implements OnInit {
   errorMessage: string|null;
 
   customClientJobKey: string = '';
+  notEmbedded: boolean = true;
 
   selectedWork: WorkToDo;
   questionId: string;
@@ -160,8 +161,16 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    // Extract job key from hash
     const parts = document.location.hash.substr(1).split('/');
     this.customClientJobKey = parts[0];
+
+    // Determine if page should render in embedded mode
+    var query = document.location.search.substr(1)
+    var embedded_query = /embedded=(true|false)/g.exec(query);
+    if (embedded_query) {
+      this.notEmbedded = embedded_query[1] == 'true' ? false : true;
+    }
 
     this.userNonce = localStorage.getItem('user_nonce');
     const maybe_local_sent_count = localStorage.getItem('local_sent_count');
@@ -205,11 +214,11 @@ export class AppComponent implements OnInit {
     // If we have a parent window, send message to it with the answer. This
     // allows the crowdsourcing interface to be embedded in an iFrame and
     // communicate with the parent window.
-    if (window.parent != window.top) {
+    if (window.self != window.top) {
       console.log('sending message with the answer to parent window');
       window.parent.postMessage(JSON.stringify(answer), '*');
     } else {
-      console.log('NOT sending message with the answer to parent window');
+      console.log('not sending message because no parent window');
     }
 
     this.http

--- a/api-service/webapp-demo/src/app/app.component.ts
+++ b/api-service/webapp-demo/src/app/app.component.ts
@@ -190,20 +190,32 @@ export class AppComponent implements OnInit {
       answerPath += '/' + this.customClientJobKey;
     }
 
+    const answer = {
+      questionId: this.questionId,
+      userNonce: this.userNonce,
+      readableAndInEnglish: this.readableAndInEnglish ? 'Yes' : 'No',
+      toxic: this.toxicityAnswer,
+      nobscene: this.obsceneAnswer,
+      insult: this.insultAnswer,
+      threat: this.threatAnswer,
+      identityHate: this.hateAnswer,
+      comments: this.comments
+    };
+
+    // If we have a parent window, send message to it with the answer. This
+    // allows the crowdsourcing interface to be embedded in an iFrame and
+    // communicate with the parent window.
+    if (window.parent != window.top) {
+      console.log('sending message with the answer to parent window');
+      window.parent.postMessage(JSON.stringify(answer), '*');
+    } else {
+      console.log('NOT sending message with the answer to parent window');
+    }
+
     this.http
-        .post(answerPath, {
-          questionId: this.questionId,
-          userNonce: this.userNonce,
-          readableAndInEnglish: this.readableAndInEnglish ? 'Yes' : 'No',
-          toxic: this.toxicityAnswer,
-          obscene: this.obsceneAnswer,
-          insult: this.insultAnswer,
-          threat: this.threatAnswer,
-          identityHate: this.hateAnswer,
-          comments: this.comments
-        })
-        .subscribe(
-            (data: {}) => {
+      .post(answerPath, answer)
+      .subscribe(
+        (data: {}) => {
               console.log(
                   `sent score; got response:` + JSON.stringify(data, null, 2));
               this.local_sent_count += 1;

--- a/api-service/webapp-demo/src/app/app.component.ts
+++ b/api-service/webapp-demo/src/app/app.component.ts
@@ -81,6 +81,7 @@ export class AppComponent implements OnInit {
   chooseRandomWorkToDo(data: WorkToDo[]): void {
     this.selectedWork = data[getRandomInt(0, data.length - 1)];
     console.log('Work to do: ', this.selectedWork);
+
     this.questionId = this.selectedWork.question_id;
     this.setDocumentHash();
     this.question = this.selectedWork.question;

--- a/api-service/webapp-demo/src/app/app.component.ts
+++ b/api-service/webapp-demo/src/app/app.component.ts
@@ -162,7 +162,7 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    // Extract job key from hash
+    // Extract ClientJobKey from hash if specified
     const parts = document.location.hash.substr(1).split('/');
     this.customClientJobKey = parts[0];
 
@@ -170,7 +170,7 @@ export class AppComponent implements OnInit {
     var query = document.location.search.substr(1)
     var embedded_query = /embedded=(true|false)/g.exec(query);
     if (embedded_query) {
-      this.notEmbedded = embedded_query[1] == 'true' ? false : true;
+      this.notEmbedded = (embedded_query[1] == 'true') ? false : true;
     }
 
     this.userNonce = localStorage.getItem('user_nonce');

--- a/api-service/webapp-demo/src/app/app.component.ts
+++ b/api-service/webapp-demo/src/app/app.component.ts
@@ -170,7 +170,7 @@ export class AppComponent implements OnInit {
     var query = document.location.search.substr(1)
     var embedded_query = /embedded=(true|false)/g.exec(query);
     if (embedded_query) {
-      this.notEmbedded = (embedded_query[1] == 'true') ? false : true;
+      this.notEmbedded = !(embedded_query[1] == 'true');
     }
 
     this.userNonce = localStorage.getItem('user_nonce');
@@ -200,12 +200,14 @@ export class AppComponent implements OnInit {
       answerPath += '/' + this.customClientJobKey;
     }
 
+    const yesEnglish = 'Yes';
+    const noEnglish = 'No';
     const answer = {
       questionId: this.questionId,
       userNonce: this.userNonce,
-      readableAndInEnglish: this.readableAndInEnglish ? 'Yes' : 'No',
+      readableAndInEnglish: this.readableAndInEnglish ? yesEnglish: noEnglish,
       toxic: this.toxicityAnswer,
-      nobscene: this.obsceneAnswer,
+      obscene: this.obsceneAnswer,
       insult: this.insultAnswer,
       threat: this.threatAnswer,
       identityHate: this.hateAnswer,


### PR DESCRIPTION
This change allows us to use this interface inside of CrowdFlower. This code has already been deployed. You can check out a test CrowdFlower job that uses it here: https://make.crowdflower.com/jobs/1236940

<img width="916" alt="screen shot 2018-02-21 at 12 41 24 pm" src="https://user-images.githubusercontent.com/3289244/36495836-8de6bca6-1704-11e8-83cc-4eb166339d39.png">

**Question** When we save answers whenever the annotator changes an answer, should we overwrite the last answer or just add a new one? 

**To Do**
- [x] Add the Javascript necessary to make this work on the CrowdFlower side to this repo
- [x] Add some documentation on how to use this interface in side CrowdFlower
- [x] Add a query param to fetch a comment by a specific ID instead of a random one from the database 
- [x] Add a query param to hide the meta data on the page

**To Do Next**
* Record the annotations whenever its changed instead of on submit
* Look into why the page is so slow to load in CrowdFlower