### PR TITLE
Allow configurable port for local dev

### DIFF
--- a/api-service/job-server-demo/README.md
+++ b/api-service/job-server-demo/README.md
@@ -23,7 +23,7 @@ Then from this directory, use yarn to install the local package dependencies:
 yarn install
 ```
 
-Setup the initial `build` directory.
+Setup the initial `build` directory and copy the server_config templates there:
 
 ```
 yarn run setup
@@ -33,14 +33,13 @@ yarn run setup
 
 Before you can deploy, you need to:
 
-1.  Copy the `server_config.template.json` file to `build/config/server_config.json`.
-2.  In the `build/config/server_config.json` file, set these values:
+1.  In the `build/config/server_config.json` file, set these values:
 
     * `cloudProjectId` This is the name of your google cloud project.
     * `clientJobKey` This is a client job key to access the api-server.
     * `apiUrl` This should be the URL of the api-server.
 
-3.  Copy the static files you want to be served into `build/static` (The
+2.  Copy the static files you want to be served into `build/static` (The
     `server_config.json` variable named `staticDir` has a default value set to
     be `build/static`). For example, once the
     [webapp-demo](../webapp-demo/README.md) is built, you can do:

--- a/api-service/job-server-demo/package.json
+++ b/api-service/job-server-demo/package.json
@@ -10,7 +10,7 @@
     "build:watch": "tsc --outdir build/server/ --watch",
     "start": "node build/server/run_server.js build/config/server_config.json",
     "start:watch": "yarn run build:watch & NODE_ENV='development' nodemon --inspect build/server/run_server.js build/config/server_config.json",
-    "start-dev": "NODE_ENV='development' node build/server/run_server.js build/config/server_config.json",
+    "start-dev": "NODE_ENV='development' NODE_PORT='3000' node build/server/run_server.js build/config/server_config.json",
     "start-prod": "NODE_ENV='production' node build/server/run_server.js build/config/server_config.json",
     "test": "mocha build/server/*_test.js"
   },

--- a/api-service/job-server-demo/src/run_server.ts
+++ b/api-service/job-server-demo/src/run_server.ts
@@ -28,6 +28,13 @@ if (process.env['NODE_ENV'] !== 'development' &&
   process.exit(1);
 }
 
+// Allow the port to be overridden by an environment variable in dev
+// so all services can be run locally simultaneously.
+if (process.env['NODE_ENV'] == 'development' && process.env['NODE_PORT']) {
+  configuration.port = (process.env['NODE_PORT'] || configuration.port);
+  console.log('Overriding the configured port with the NODE_PORT env variable');
+}
+
 if (!configuration.cloudProjectId) {
   console.error(
       'The config file build/config/server_config.json needs to specify' +
@@ -59,6 +66,7 @@ if (IS_PRODUCTION) {
 }
 
 import * as serving from './serving'
+
 let server = new serving.Server(configuration);
 server.start()
     .then(() => {

--- a/api-service/job-server-demo/src/run_server.ts
+++ b/api-service/job-server-demo/src/run_server.ts
@@ -66,7 +66,6 @@ if (IS_PRODUCTION) {
 }
 
 import * as serving from './serving'
-
 let server = new serving.Server(configuration);
 server.start()
     .then(() => {

--- a/api-service/webapp-demo/proxy.conf.json
+++ b/api-service/webapp-demo/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:8080",
+    "target": "http://localhost:3000",
     "secure": false
   }
 }


### PR DESCRIPTION
To do local development, you currently have to run three services and two of them run on `8080` by default. Not ideal for local development. 

This change allows the port of the job-server to be overridden in development mode. Now when you run `yarn run start-dev` from the `job-server-demo`, the API will run on port `3000` by default. I updated the `web-app-demo` proxy config to proxy through port `3000` as well, so everything should work locally and remotely without doing any extra configuration. 

This closes https://github.com/conversationai/conversationai-crowdsource/issues/11.