### PR TITLE
Adds a component + tests for the identity category and hate labeling job

### DIFF
--- a/api-service/webapp-demo/karma.conf.js
+++ b/api-service/webapp-demo/karma.conf.js
@@ -12,6 +12,12 @@ module.exports = function (config) {
       require('karma-coverage-istanbul-reporter'),
       require('@angular/cli/plugins/karma')
     ],
+    files: [
+      {pattern: './src/test.ts', watched: false},
+      // Include Material theme file for material components to work correctly
+      // in tests.
+      'node_modules/@angular/material/prebuilt-themes/indigo-pink.css'
+    ],
     client:{
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
@@ -28,6 +34,7 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['Chrome'],
+    //browsers: ['ChromeHeadless'], # Use for remote work
     singleRun: false,
     browserDisconnectTolerance: 2,
     browserNoActivityTimeout: 50000,

--- a/api-service/webapp-demo/package.json
+++ b/api-service/webapp-demo/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "start:dev": "ng serve --port 8888 --proxy-config proxy.conf.json",
+    "start:dev": "ng serve --proxy-config proxy.conf.json",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/api-service/webapp-demo/package.json
+++ b/api-service/webapp-demo/package.json
@@ -27,6 +27,7 @@
     "@angular/platform-browser-dynamic": "^4.0.0",
     "@angular/router": "^4.0.0",
     "core-js": "^2.4.1",
+    "hammerjs": "^2.0.8",
     "rxjs": "^5.4.1",
     "zone.js": "^0.8.14"
   },

--- a/api-service/webapp-demo/package.json
+++ b/api-service/webapp-demo/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "start:dev": "ng serve --proxy-config proxy.conf.json",
+    "start:dev": "ng serve --port 8888 --proxy-config proxy.conf.json",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/api-service/webapp-demo/src/app/app.module.ts
+++ b/api-service/webapp-demo/src/app/app.module.ts
@@ -41,6 +41,7 @@ import {HttpClientModule} from '@angular/common/http';
 
 import { AppComponent } from './app.component';
 import { BaseJobComponent } from './base_job.component';
+import { IdentityCategoryHateJobComponent } from './identity_category_hate_job.component';
 import { TestJobComponent } from './test_job.component';
 import { CrowdSourceApiService} from './crowd_source_api.service';
 
@@ -54,6 +55,14 @@ const appRoutes: Routes = [
   {
     path: 'test_job/:customClientJobKey',
     component: TestJobComponent
+  },
+  {
+    path: 'identity_category_hate_job',
+    component: IdentityCategoryHateJobComponent
+  },
+  {
+    path: 'identity_category_hate_job/:customClientJobKey',
+    component: IdentityCategoryHateJobComponent
   },
   {
     path: '',
@@ -107,6 +116,7 @@ const appRoutes: Routes = [
   declarations: [
     AppComponent,
     BaseJobComponent,
+    IdentityCategoryHateJobComponent,
     TestJobComponent
   ],
   providers: [CrowdSourceApiService],

--- a/api-service/webapp-demo/src/app/base_job.component.ts
+++ b/api-service/webapp-demo/src/app/base_job.component.ts
@@ -239,4 +239,12 @@ export class BaseJobComponent implements OnInit {
     this.errorMessage = null;
   }
 
+  // Debugging method that clears the current questionId from the url and
+  // fetches a new question if there is an error.
+  clearQuestionAndGetNext() {
+    this.questionId = null;
+    this.clearError();
+    this.getNextWorkItem();
+  }
+
 }

--- a/api-service/webapp-demo/src/app/identity_category_hate_job.component.css
+++ b/api-service/webapp-demo/src/app/identity_category_hate_job.component.css
@@ -1,3 +1,11 @@
+.demo-tab-group {
+  border: 1px solid #e8e8e8;
+}
+
+.demo-tab-content {
+  padding: 16px;
+}
+
 .text-header {
   font-weight: bold;
 }
@@ -38,4 +46,17 @@
 
 .hatefulQuestion {
   padding: 10px;
+}
+
+.hateDetailQuestionOption {
+  padding-left: 20px;
+  padding-top: 5px;
+  display: block;
+}
+
+.hateDetailQuestionHeader {
+  padding-left: 20px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  font-weight: bold;
 }

--- a/api-service/webapp-demo/src/app/identity_category_hate_job.component.css
+++ b/api-service/webapp-demo/src/app/identity_category_hate_job.component.css
@@ -1,0 +1,41 @@
+.text-header {
+  font-weight: bold;
+}
+
+.text {
+  padding: 10px;
+  border: 1px solid #CCC;
+  margin: 10px;
+}
+
+.counts {
+  text-align: right;
+  padding: 5px;
+  font-size: 80%;
+}
+
+.id {
+  text-align: right;
+  padding: 5px;
+  font-size: 80%;
+}
+
+.errorMessage {
+  font-weight: bold;
+  padding: 10px;
+  border: 1px solid #FCC;
+  margin: 10px;
+  color: #933;
+}
+
+.questionWrapper {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.identityQuestion {
+}
+
+.hatefulQuestion {
+  padding: 10px;
+}

--- a/api-service/webapp-demo/src/app/identity_category_hate_job.component.html
+++ b/api-service/webapp-demo/src/app/identity_category_hate_job.component.html
@@ -1,0 +1,43 @@
+<!--The content below is only a placeholder and can be replaced.-->
+<h1>Conversation AI Crowdsourcing Demo</h1>
+
+<div class="counts" *ngIf="notEmbedded">
+  <div>my worker id: {{userNonce}}</div>
+  <div>local_sent_count: {{local_sent_count}}</div>
+  <div>training_answer_count: {{training_answer_count}}</div>
+  <div>user_mean_score: {{user_mean_score}}</div>
+  <div>overall_job_answer_count: {{overall_job_answer_count}}</div>
+  <div>overall_job_mean_score: {{overall_job_mean_score}}</div>
+</div>
+
+<div *ngIf="errorMessage" class="errorMessage" (click)="clearError()">{{errorMessage}}</div>
+
+<div *ngIf="!question">
+  Loading...
+</div>
+
+<div *ngIf="question">
+  <div class="id" *ngIf="notEmbedded">{{question.id}}</div>
+  <div class="text-header">Comment to rate:</div>
+  <div class="text">{{question.text}}</div>
+
+  <div *ngFor="let identity of identities" class="questionWrapper">
+    <mat-checkbox [(ngModel)]="labels[identity].markedAsCategory"
+                  (change)="labels[identity].hateful = labels[identity].markedAsCategory && labels[identity].hateful"
+                  class="identityQuestion">
+      The comment is about the identity group "{{identity}}".
+    </mat-checkbox>
+
+    <mat-checkbox *ngIf="labels[identity].markedAsCategory"
+                  [(ngModel)]="labels[identity].hateful"
+                  class="hatefulQuestion"
+                  color="accent">
+      The comment is hateful towards the identity group "{{identity}}".
+    </mat-checkbox>
+  </div>
+
+  <div>
+    <button mat-raised-button color="primary" (click)="sendScoreToApi()">Submit</button>
+  </div>
+
+</div>

--- a/api-service/webapp-demo/src/app/identity_category_hate_job.component.html
+++ b/api-service/webapp-demo/src/app/identity_category_hate_job.component.html
@@ -46,8 +46,8 @@
       </div>
     </mat-tab>
     <mat-tab label="Detailed hate labels">
-      <div class="demo-tab-content">
-        <div *ngFor="let identity of identities" class="questionWrapper">
+      <div class="demo-tab-content detailedLabels">
+        <div *ngFor="let identity of identities" class="questionWrapper foo">
           <mat-checkbox [(ngModel)]="detailLabels[identity].markedAsCategory"
                         class="identityQuestion"
                         (change)="clearHatefulLabelsIfCategoryDeselected(identity)">

--- a/api-service/webapp-demo/src/app/identity_category_hate_job.component.html
+++ b/api-service/webapp-demo/src/app/identity_category_hate_job.component.html
@@ -1,5 +1,4 @@
-<!--The content below is only a placeholder and can be replaced.-->
-<h1>Conversation AI Crowdsourcing Demo</h1>
+<h1>Identity category hate labeling job</h1>
 
 <div class="counts" *ngIf="notEmbedded">
   <div>my worker id: {{userNonce}}</div>
@@ -11,6 +10,9 @@
 </div>
 
 <div *ngIf="errorMessage" class="errorMessage" (click)="clearError()">{{errorMessage}}</div>
+<div *ngIf="errorMessage">
+  <button mat-button (click)="clearQuestionAndGetNext()">Get a new question</button>
+</div>
 
 <div *ngIf="!question">
   Loading...
@@ -21,20 +23,52 @@
   <div class="text-header">Comment to rate:</div>
   <div class="text">{{question.text}}</div>
 
-  <div *ngFor="let identity of identities" class="questionWrapper">
-    <mat-checkbox [(ngModel)]="labels[identity].markedAsCategory"
-                  (change)="labels[identity].hateful = labels[identity].markedAsCategory && labels[identity].hateful"
-                  class="identityQuestion">
-      The comment is about the identity group "{{identity}}".
-    </mat-checkbox>
+  <!-- TODO(rachelrosen): Consider providing a "sequence" UI where the user is presented with a question for only one
+       identity at a time, so that they always see the comment when answering the question, and it doesn't seem like
+       "too much".-->
+  <mat-tab-group class="demo-tab-group" (selectedTabChange)="resetQuestionUI()" [(selectedIndex)]="selectedTabIndex">
+    <mat-tab label="Boolean hate labels">
+      <div class="demo-tab-content">
+        <div *ngFor="let identity of identities" class="questionWrapper">
+          <mat-checkbox [(ngModel)]="booleanLabels[identity].markedAsCategory"
+                        (change)="booleanLabels[identity].hateful = booleanLabels[identity].markedAsCategory && booleanLabels[identity].hateful"
+                        class="identityQuestion">
+            The comment is about the identity group "{{identity}}".
+          </mat-checkbox>
 
-    <mat-checkbox *ngIf="labels[identity].markedAsCategory"
-                  [(ngModel)]="labels[identity].hateful"
-                  class="hatefulQuestion"
-                  color="accent">
-      The comment is hateful towards the identity group "{{identity}}".
-    </mat-checkbox>
-  </div>
+          <mat-checkbox *ngIf="booleanLabels[identity].markedAsCategory"
+                        [(ngModel)]="booleanLabels[identity].hateful"
+                        class="hatefulQuestion"
+                        color="accent">
+            The comment is hateful towards the identity group "{{identity}}".
+          </mat-checkbox>
+        </div>
+      </div>
+    </mat-tab>
+    <mat-tab label="Detailed hate labels">
+      <div class="demo-tab-content">
+        <div *ngFor="let identity of identities" class="questionWrapper">
+          <mat-checkbox [(ngModel)]="detailLabels[identity].markedAsCategory"
+                        class="identityQuestion"
+                        (change)="clearHatefulLabelsIfCategoryDeselected(identity)">
+            The comment is about the identity group "{{identity}}".
+          </mat-checkbox>
+
+          <div *ngIf="detailLabels[identity].markedAsCategory">
+            <div class="hateDetailQuestionHeader">Does this comment...</div>
+            <mat-checkbox *ngFor="let option of detailedHateOptions" class="hateDetailQuestionOption" color="accent"
+                          [(ngModel)]="detailLabels[identity].hatefulLabels[option.key]"
+                          (change)="clearNoneLabelIfHateDetailsSelected($event, noneCheckbox)">
+              {{option.text}} "{{identity}}"?
+            </mat-checkbox>
+            <mat-checkbox #noneCheckbox class="hateDetailQuestionOption" color="accent" (change)="clearHateDetailLabelsIfNoneSelected($event, identity)">
+              None of the above
+            </mat-checkbox>
+          </div>
+        </div>
+      </div>
+    </mat-tab>
+  </mat-tab-group>
 
   <div>
     <button mat-raised-button color="primary" (click)="sendScoreToApi()">Submit</button>

--- a/api-service/webapp-demo/src/app/identity_category_hate_job.component.html
+++ b/api-service/webapp-demo/src/app/identity_category_hate_job.component.html
@@ -26,7 +26,7 @@
   <!-- TODO(rachelrosen): Consider providing a "sequence" UI where the user is presented with a question for only one
        identity at a time, so that they always see the comment when answering the question, and it doesn't seem like
        "too much".-->
-  <mat-tab-group class="demo-tab-group" (selectedTabChange)="resetQuestionUI()" [(selectedIndex)]="selectedTabIndex">
+  <mat-tab-group id="tabGroup" class="demo-tab-group" (selectedTabChange)="resetQuestionUI()" [(selectedIndex)]="selectedTabIndex">
     <mat-tab label="Boolean hate labels">
       <div class="demo-tab-content">
         <div *ngFor="let identity of identities" class="questionWrapper">

--- a/api-service/webapp-demo/src/app/identity_category_hate_job.component.spec.ts
+++ b/api-service/webapp-demo/src/app/identity_category_hate_job.component.spec.ts
@@ -1,6 +1,6 @@
 import { Component, Injectable, ViewChild } from '@angular/core';
 import { Location } from '@angular/common';
-import { TestBed, async, inject } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async, inject } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule, ReactiveFormsModule }   from '@angular/forms';
 import { HttpClientModule, HttpRequest } from '@angular/common/http';
@@ -29,6 +29,9 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { BaseJobComponent } from './base_job.component';
 import { IdentityCategoryHateJobComponent } from './identity_category_hate_job.component';
 import { CrowdSourceApiService } from './crowd_source_api.service';
+
+const HATE_DETAIL_OPTION_COUNT = 5;
+const DETAIL_TAB = 1;
 
 // Test component wrapper for BaseJobComponent.
 @Component({
@@ -86,7 +89,8 @@ class ParamMapStub implements ParamMap {
 }
 
 function setupQuestionMocks(httpMock: HttpTestingController,
-                            customClientJobKey: string) {
+                            customClientJobKey: string,
+                            fixture: ComponentFixture<IdentityCategoryHateJobTestComponent>) {
   // Verify the call to load a question.
   httpMock.expectOne('/api/work/' + customClientJobKey).flush([{
     question_id: 'foo',
@@ -94,6 +98,7 @@ function setupQuestionMocks(httpMock: HttpTestingController,
     answers_per_question: 10,
     answer_count: 5
   }]);
+  fixture.detectChanges();
 }
 
 function verifyQualityApiCalls(httpMock: HttpTestingController) {
@@ -112,6 +117,34 @@ function verifyQualityApiCalls(httpMock: HttpTestingController) {
     answer_count: 20,
     mean_score: 1.5
   });
+}
+
+function changeToTab(tabNumber: number, fixture: ComponentFixture<IdentityCategoryHateJobTestComponent>) {
+  const tabs = fixture.debugElement.query(By.css('#tabGroup')).componentInstance;
+  tabs.selectedIndex = tabNumber;
+  fixture.detectChanges();
+}
+
+function getAllFalseHatefulDetailLabels(): {} {
+  return {
+    slurs: false,
+    violence: false,
+    false_accusations: false,
+    other_hate: false
+  }
+};
+
+function toggleCategoryBoxForItem(fixture: ComponentFixture<IdentityCategoryHateJobTestComponent>,
+                                  index: number,
+                                  tab = 0) {
+  const questionSelector = tab === 0 ? '.identityQuestion' : '.detailedLabels .identityQuestion';
+  const questions = fixture.debugElement.queryAll(By.css(questionSelector));
+  // Note: calling toggle() on the componentInstance does not update the
+  // template in the test, and calling click() on the nativeElement also has
+  // no effect. This is true when after calling whenStable().
+  // TODO(rachelrosen): Investigate why this happens.
+  questions[index].nativeElement.querySelector('input').click();
+  fixture.detectChanges();
 }
 
 let activatedRoute: ActivatedRouteStub;
@@ -176,25 +209,23 @@ describe('IdentityCategoryHateJobComponent tests', () => {
 
     expect(fixture.nativeElement.textContent).toContain('Loading');
 
-    setupQuestionMocks(httpMock, 'testJobKey');
+    setupQuestionMocks(httpMock, 'testJobKey', fixture);
 
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toContain('Hello world!');
   }))));
 
-  // TODO(rachelrosen): Maybe split this up into separate tests?
-  it('UI interaction for boolean labels tab', async(
+  it('Boolean labels: Shows hateful option when category checkbox is checked', async(
     (inject([HttpTestingController], (httpMock: HttpTestingController) => {
     activatedRoute.testParams = {
       customClientJobKey: 'testJobKey'
     };
 
     const fixture = TestBed.createComponent(IdentityCategoryHateJobTestComponent);
-    fixture.componentInstance.setTestIdentities(["cats", "dogs", "rabbits"]);
+    fixture.componentInstance.setTestIdentities(["cats", "dogs"]);
     fixture.detectChanges();
-    setupQuestionMocks(httpMock, 'testJobKey');
-    fixture.detectChanges();
+    setupQuestionMocks(httpMock, 'testJobKey', fixture);
 
     const jobComponent = fixture.componentInstance.identityJobComponent;
 
@@ -203,63 +234,430 @@ describe('IdentityCategoryHateJobComponent tests', () => {
 
     // Checks that the question for all identities are displayed.
     const questions = fixture.debugElement.queryAll(By.css('.identityQuestion'));
-    expect(questions.length).toEqual(3);
+    expect(questions.length).toEqual(2);
     let hateQuestions = fixture.debugElement.queryAll(By.css('.hatefulQuestion'));
     expect(hateQuestions.length).toEqual(0);
 
-    // Checks that questions about hate are displayed after clicking the
-    // checkboxes for the questions.
-    // Note: calling toggle() on the componentInstance does not update the
-    // template in the test, and calling click() on the nativeElement also has
-    // no effect. This is true when after calling whenStable().
-    // TODO(rachelrosen): Investigate why this happens.
-    questions[0].nativeElement.querySelector('input').click();
-    questions[2].nativeElement.querySelector('input').click();
-    fixture.detectChanges();
+    expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+      {category: 'cats', markedAsCategory: false, hateful: false},
+      {category: 'dogs', markedAsCategory: false, hateful: false},
+    ]);
+
+    // Checks the category box for the first group.
+    toggleCategoryBoxForItem(fixture, 0);
 
     hateQuestions = fixture.debugElement.queryAll(By.css('.hatefulQuestion'));
-    expect(hateQuestions.length).toEqual(2);
-
+    expect(hateQuestions.length).toEqual(1);
     expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
       {category: 'cats', markedAsCategory: true, hateful: false},
       {category: 'dogs', markedAsCategory: false, hateful: false},
-      {category: 'rabbits', markedAsCategory: true, hateful: false}
     ]);
 
-    // Check the hateful label box for the first group.
-    hateQuestions[0].nativeElement.querySelector('input').click();
+    // Checks the category box for the second group.
+    toggleCategoryBoxForItem(fixture, 1);
 
+    hateQuestions = fixture.debugElement.queryAll(By.css('.hatefulQuestion'));
+    expect(hateQuestions.length).toEqual(2);
     expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
-      {category: 'cats', markedAsCategory: true, hateful: true},
-      {category: 'dogs', markedAsCategory: false, hateful: false},
-      {category: 'rabbits', markedAsCategory: true, hateful: false}
+      {category: 'cats', markedAsCategory: true, hateful: false},
+      {category: 'dogs', markedAsCategory: true, hateful: false},
     ]);
 
-    // Check the hateful label box for the third group.
-    hateQuestions[1].nativeElement.querySelector('input').click();
+    // Un-checks the category box for the first group.
+    toggleCategoryBoxForItem(fixture, 0);
 
-    expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
-      {category: 'cats', markedAsCategory: true, hateful: true},
-      {category: 'dogs', markedAsCategory: false, hateful: false},
-      {category: 'rabbits', markedAsCategory: true, hateful: true}
-    ]);
-
-    // Uncheck one of the selected checkboxes, and check that the hateful
-    // question is hidden again and the hate value has been reset.
-    questions[2].nativeElement.querySelector('input').click();
-    fixture.detectChanges();
     hateQuestions = fixture.debugElement.queryAll(By.css('.hatefulQuestion'));
     expect(hateQuestions.length).toEqual(1);
-
     expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
-      {category: 'cats', markedAsCategory: true, hateful: true},
+      {category: 'cats', markedAsCategory: false, hateful: false},
+      {category: 'dogs', markedAsCategory: true, hateful: false},
+    ]);
+
+    // Un-checks the category box for the second group.
+    toggleCategoryBoxForItem(fixture, 1);
+
+    hateQuestions = fixture.debugElement.queryAll(By.css('.hatefulQuestion'));
+    expect(hateQuestions.length).toEqual(0);
+    expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+      {category: 'cats', markedAsCategory: false, hateful: false},
       {category: 'dogs', markedAsCategory: false, hateful: false},
-      {category: 'rabbits', markedAsCategory: false, hateful: false}
     ]);
   }))));
 
-  // TODO(rachelrosen): Write this test.
-  xit('UI interaction for detailed labels tab', async(
+  it('Boolean labels: Unchecking identity unchecks hate option', async(
     (inject([HttpTestingController], (httpMock: HttpTestingController) => {
+    activatedRoute.testParams = {
+      customClientJobKey: 'testJobKey'
+    };
+
+    const fixture = TestBed.createComponent(IdentityCategoryHateJobTestComponent);
+    fixture.componentInstance.setTestIdentities(["foo"]);
+    fixture.detectChanges();
+    setupQuestionMocks(httpMock, 'testJobKey', fixture);
+
+    const jobComponent = fixture.componentInstance.identityJobComponent;
+    expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+      {category: 'foo', markedAsCategory: false, hateful: false},
+    ]);
+
+    const questions = fixture.debugElement.queryAll(By.css('.identityQuestion'));
+
+    // Checks the box for the first identity.
+    toggleCategoryBoxForItem(fixture, 0);
+
+    expect(questions[0].componentInstance.checked).toBe(true);
+    expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+      {category: 'foo', markedAsCategory: true, hateful: false},
+    ]);
+
+    let hateQuestions = fixture.debugElement.queryAll(By.css('.hatefulQuestion'));
+    expect(hateQuestions.length).toEqual(1);
+
+    // Checks the hateful box for the first identity.
+    hateQuestions[0].nativeElement.querySelector('input').click();
+    fixture.detectChanges();
+
+    hateQuestions = fixture.debugElement.queryAll(By.css('.hatefulQuestion'));
+    expect(hateQuestions.length).toEqual(1);
+    expect(hateQuestions[0].componentInstance.checked).toBe(true);
+    expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+      {category: 'foo', markedAsCategory: true, hateful: true},
+    ]);
+
+    // Unchecks the box for the first identity.
+    toggleCategoryBoxForItem(fixture, 0);
+
+    hateQuestions = fixture.debugElement.queryAll(By.css('.hatefulQuestion'));
+    expect(hateQuestions.length).toEqual(0);
+    expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+      {category: 'foo', markedAsCategory: false, hateful: false},
+    ]);
+
+    // Re-checks the box for the first identity.
+    questions[0].nativeElement.querySelector('input').click();
+    fixture.detectChanges();
+
+    hateQuestions = fixture.debugElement.queryAll(By.css('.hatefulQuestion'));
+    expect(hateQuestions[0].componentInstance.checked).toBe(false);
+    expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+      {category: 'foo', markedAsCategory: true, hateful: false},
+    ]);
+  }))));
+
+  it('Detailed labels: Unchecking identity unchecks all detail options', async(
+    (inject([HttpTestingController], (httpMock: HttpTestingController) => {
+    activatedRoute.testParams = {
+      customClientJobKey: 'testJobKey'
+    };
+
+
+    const fixture = TestBed.createComponent(IdentityCategoryHateJobTestComponent);
+    fixture.componentInstance.setTestIdentities(["foo"]);
+    fixture.detectChanges();
+    setupQuestionMocks(httpMock, 'testJobKey', fixture);
+
+    const jobComponent = fixture.componentInstance.identityJobComponent;
+    changeToTab(DETAIL_TAB, fixture);
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        { category: 'foo', markedAsCategory: false, hatefulLabels: getAllFalseHatefulDetailLabels()},
+      ]);
+
+      const questions = fixture.debugElement.queryAll(By.css('.detailedLabels .identityQuestion'));
+
+      // Check the box for the identity.
+      toggleCategoryBoxForItem(fixture, 0, DETAIL_TAB);
+
+      expect(questions[0].componentInstance.checked).toBe(true);
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        { category: 'foo', markedAsCategory: true, hatefulLabels: getAllFalseHatefulDetailLabels() },
+      ]);
+
+      let hateQuestions = fixture.debugElement.queryAll(By.css('.detailedLabels .hateDetailQuestionOption'));
+
+      // Checks two of the hate detail options
+      hateQuestions[0].nativeElement.querySelector('input').click();
+      hateQuestions[1].nativeElement.querySelector('input').click();
+      fixture.detectChanges();
+
+      expect(hateQuestions[0].componentInstance.checked).toBe(true);
+      expect(hateQuestions[1].componentInstance.checked).toBe(true);
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        {
+          category: 'foo',
+          markedAsCategory: true,
+          hatefulLabels: {
+            slurs: true,
+            violence: true,
+            false_accusations: false,
+            other_hate: false
+          }
+        },
+      ]);
+
+      // Uncheck the box for the identity.
+      toggleCategoryBoxForItem(fixture, 0, DETAIL_TAB);
+
+      hateQuestions = fixture.debugElement.queryAll(By.css('.detailedLabels .hateDetailQuestionOption'));
+      expect(hateQuestions.length).toEqual(0);
+      expect(questions[0].componentInstance.checked).toBe(false);
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        { category: 'foo', markedAsCategory: false, hatefulLabels: getAllFalseHatefulDetailLabels() },
+      ]);
+
+      // Re-checks the box for the identity
+      toggleCategoryBoxForItem(fixture, 0, DETAIL_TAB);
+
+      hateQuestions = fixture.debugElement.queryAll(By.css('.detailedLabels .hateDetailQuestionOption'));
+      expect(hateQuestions[0].componentInstance.checked).toBe(false);
+      expect(hateQuestions[1].componentInstance.checked).toBe(false);
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        { category: 'foo', markedAsCategory: true, hatefulLabels: getAllFalseHatefulDetailLabels()},
+      ]);
+    });
+  }))));
+
+
+  it('Detailed labels: Shows hateful detail options when category checkbox is checked', async(
+    (inject([HttpTestingController], (httpMock: HttpTestingController) => {
+    activatedRoute.testParams = {
+      customClientJobKey: 'testJobKey'
+    };
+
+    const HATE_DETAIL_OPTION_COUNT = 5;
+
+    const fixture = TestBed.createComponent(IdentityCategoryHateJobTestComponent);
+    fixture.componentInstance.setTestIdentities(["cats", "dogs"]);
+    fixture.detectChanges();
+    setupQuestionMocks(httpMock, 'testJobKey', fixture);
+
+    const jobComponent = fixture.componentInstance.identityJobComponent;
+
+    const tabs = fixture.debugElement.query(By.css('#tabGroup')).componentInstance;
+    expect(tabs.selectedIndex).toEqual(0);
+
+    changeToTab(DETAIL_TAB, fixture);
+
+    // Use whenStable() to wait for tab switching animation, otherwise the UI in
+    // the rest of the test can get into an invalid state.
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(tabs.selectedIndex).toEqual(DETAIL_TAB);
+
+      // Checks that the question for all identities are displayed.
+      const questions = fixture.debugElement.queryAll(By.css('.detailedLabels .identityQuestion'));
+      expect(questions.length).toEqual(2);
+      let hateQuestions = fixture.debugElement.queryAll(By.css('.detailedLabels .hateDetailQuestionOption'));
+      expect(hateQuestions.length).toEqual(0);
+
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        { category: 'cats', markedAsCategory: false, hatefulLabels: getAllFalseHatefulDetailLabels() },
+        { category: 'dogs', markedAsCategory: false, hatefulLabels: getAllFalseHatefulDetailLabels() },
+      ]);
+
+      // Check the box for the first identity.
+      toggleCategoryBoxForItem(fixture, 0, DETAIL_TAB);
+
+      hateQuestions = fixture.debugElement.queryAll(By.css('.detailedLabels .hateDetailQuestionOption'));
+      expect(hateQuestions.length).toEqual(HATE_DETAIL_OPTION_COUNT);
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        { category: 'cats', markedAsCategory: true, hatefulLabels: getAllFalseHatefulDetailLabels() },
+        { category: 'dogs', markedAsCategory: false, hatefulLabels: getAllFalseHatefulDetailLabels() },
+      ]);
+
+      // Check the box for the second identity.
+      toggleCategoryBoxForItem(fixture, 1, DETAIL_TAB);
+
+      hateQuestions = fixture.debugElement.queryAll(By.css('.detailedLabels .hateDetailQuestionOption'));
+      expect(hateQuestions.length).toEqual(2 * HATE_DETAIL_OPTION_COUNT);
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        { category: 'cats', markedAsCategory: true, hatefulLabels: getAllFalseHatefulDetailLabels() },
+        { category: 'dogs', markedAsCategory: true, hatefulLabels: getAllFalseHatefulDetailLabels() },
+      ]);
+
+      // Unchecks the box for the first identity.
+      toggleCategoryBoxForItem(fixture, 0, DETAIL_TAB);
+
+      hateQuestions = fixture.debugElement.queryAll(By.css('.detailedLabels .hateDetailQuestionOption'));
+      expect(hateQuestions.length).toEqual(HATE_DETAIL_OPTION_COUNT);
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        { category: 'cats', markedAsCategory: false, hatefulLabels: getAllFalseHatefulDetailLabels() },
+        { category: 'dogs', markedAsCategory: true, hatefulLabels: getAllFalseHatefulDetailLabels() },
+      ]);
+
+      // Unchecks the box for the second identity.
+      toggleCategoryBoxForItem(fixture, 1, DETAIL_TAB);
+
+      hateQuestions = fixture.debugElement.queryAll(By.css('.detailedLabels .hateDetailQuestionOption'));
+      expect(hateQuestions.length).toEqual(0);
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        { category: 'cats', markedAsCategory: false, hatefulLabels: getAllFalseHatefulDetailLabels() },
+        { category: 'dogs', markedAsCategory: false, hatefulLabels: getAllFalseHatefulDetailLabels() },
+      ]);
+    });
+  }))));
+
+  it('Detailed labels: Checking "None of the Above" unchecks other detail options', async(
+    (inject([HttpTestingController], (httpMock: HttpTestingController) => {
+    activatedRoute.testParams = {
+      customClientJobKey: 'testJobKey'
+    };
+
+    const HATE_DETAIL_OPTION_COUNT = 5;
+
+    const fixture = TestBed.createComponent(IdentityCategoryHateJobTestComponent);
+    fixture.componentInstance.setTestIdentities(["foo"]);
+    fixture.detectChanges();
+    setupQuestionMocks(httpMock, 'testJobKey', fixture);
+
+    const jobComponent = fixture.componentInstance.identityJobComponent;
+
+    changeToTab(1, fixture);
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        {
+          category: 'foo',
+          markedAsCategory: false,
+          hatefulLabels: getAllFalseHatefulDetailLabels()
+        },
+      ]);
+
+      const questions = fixture.debugElement.queryAll(By.css('.detailedLabels .identityQuestion'));
+
+      // Check the box for the identity.
+      toggleCategoryBoxForItem(fixture, 0, DETAIL_TAB);
+
+      expect(questions[0].componentInstance.checked).toBe(true);
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        {
+          category: 'foo',
+          markedAsCategory: true,
+          hatefulLabels: getAllFalseHatefulDetailLabels()
+        },
+      ]);
+
+      const hateQuestions = fixture.debugElement.queryAll(By.css('.detailedLabels .hateDetailQuestionOption'));
+
+      // Checks two of the hate detail options
+      hateQuestions[0].nativeElement.querySelector('input').click();
+      hateQuestions[1].nativeElement.querySelector('input').click();
+
+      fixture.detectChanges();
+
+      expect(hateQuestions[0].componentInstance.checked).toBe(true);
+      expect(hateQuestions[1].componentInstance.checked).toBe(true);
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        {
+          category: 'foo',
+          markedAsCategory: true,
+          hatefulLabels: {
+            slurs: true,
+            violence: true,
+            false_accusations: false,
+            other_hate: false
+          }
+        },
+      ]);
+
+      // Checks "None of the above"
+      hateQuestions[HATE_DETAIL_OPTION_COUNT - 1].nativeElement.querySelector('input').click();
+      fixture.detectChanges();
+
+      // Wait for the changes that happen as a result of the first
+      // detectChanges, which calls a function that updates variables bound to
+      // the checkbox state.
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(hateQuestions[0].componentInstance.checked).toBe(false);
+        expect(hateQuestions[1].componentInstance.checked).toBe(false);
+        expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+          {
+            category: 'foo',
+            markedAsCategory: true,
+            hatefulLabels: getAllFalseHatefulDetailLabels()
+          },
+        ]);
+      });
+    });
+  }))));
+
+  it('Detailed labels: Checking detail options unchecks "None of the Above"', async(
+    (inject([HttpTestingController], (httpMock: HttpTestingController) => {
+    activatedRoute.testParams = {
+      customClientJobKey: 'testJobKey'
+    };
+
+    const HATE_DETAIL_OPTION_COUNT = 5;
+
+    const fixture = TestBed.createComponent(IdentityCategoryHateJobTestComponent);
+    fixture.componentInstance.setTestIdentities(["foo"]);
+    fixture.detectChanges();
+    setupQuestionMocks(httpMock, 'testJobKey', fixture);
+
+    const jobComponent = fixture.componentInstance.identityJobComponent;
+    changeToTab(1, fixture);
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        {
+          category: 'foo',
+          markedAsCategory: false,
+          hatefulLabels: getAllFalseHatefulDetailLabels()
+        },
+      ]);
+
+      const questions = fixture.debugElement.queryAll(By.css('.detailedLabels .identityQuestion'));
+
+      // Check the box for the identity.
+      toggleCategoryBoxForItem(fixture, 0, DETAIL_TAB);
+
+      expect(questions[0].componentInstance.checked).toBe(true);
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        {
+          category: 'foo',
+          markedAsCategory: true,
+          hatefulLabels: getAllFalseHatefulDetailLabels()
+        },
+      ]);
+
+      const hateQuestions = fixture.debugElement.queryAll(By.css('.detailedLabels .hateDetailQuestionOption'));
+
+      // Checks "None of the above"
+      hateQuestions[HATE_DETAIL_OPTION_COUNT - 1].nativeElement.querySelector('input').click();
+      fixture.detectChanges();
+
+      expect(hateQuestions[HATE_DETAIL_OPTION_COUNT - 1].componentInstance.checked).toBe(true);
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        {
+          category: 'foo',
+          markedAsCategory: true,
+          hatefulLabels: getAllFalseHatefulDetailLabels()
+        },
+      ]);
+
+      // Checks one of the hate detail options
+      hateQuestions[0].nativeElement.querySelector('input').click();
+      fixture.detectChanges();
+
+      expect(hateQuestions[0].componentInstance.checked).toBe(true);
+      expect(hateQuestions[HATE_DETAIL_OPTION_COUNT - 1].componentInstance.checked).toBe(false);
+      expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+        {
+          category: 'foo',
+          markedAsCategory: true,
+          hatefulLabels: {
+            slurs: true,
+            violence: false,
+            false_accusations: false,
+            other_hate: false
+          }
+        },
+      ]);
+    });
   }))));
 });

--- a/api-service/webapp-demo/src/app/identity_category_hate_job.component.spec.ts
+++ b/api-service/webapp-demo/src/app/identity_category_hate_job.component.spec.ts
@@ -1,0 +1,265 @@
+import { Component, Injectable, ViewChild } from '@angular/core';
+import { Location } from '@angular/common';
+import { TestBed, async, inject } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FormsModule, ReactiveFormsModule }   from '@angular/forms';
+import { HttpClientModule, HttpRequest } from '@angular/common/http';
+import { ActivatedRoute, ParamMap, Router } from '@angular/router';
+import {
+  HttpClientTestingModule,
+  HttpTestingController
+} from '@angular/common/http/testing';
+import {
+  BaseRequestOptions,
+  Http,
+  Response,
+  ResponseOptions,
+  XHRBackend
+} from '@angular/http';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import {
+  MatButtonModule,
+  MatCardModule,
+  MatCheckboxModule,
+  MatInputModule,
+  MatTabsModule,
+} from '@angular/material';
+import { By } from '@angular/platform-browser';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { BaseJobComponent } from './base_job.component';
+import { IdentityCategoryHateJobComponent } from './identity_category_hate_job.component';
+import { CrowdSourceApiService } from './crowd_source_api.service';
+
+// Test component wrapper for BaseJobComponent.
+@Component({
+  selector: 'base-job-test',
+  template: `<identity-category-hate-job [identities]="testIdentities"></identity-category-hate-job>`
+})
+class IdentityCategoryHateJobTestComponent {
+  @ViewChild(IdentityCategoryHateJobComponent)
+  identityJobComponent: IdentityCategoryHateJobComponent;
+
+  testIdentities: string[];
+
+  setTestIdentities(identities: string[]) {
+    this.testIdentities = identities;
+  }
+}
+
+// Stub for ActivatedRoute.
+@Injectable()
+class ActivatedRouteStub {
+  private paramsSubject = new BehaviorSubject(this.testParams);
+  paramMap = this.paramsSubject.asObservable();
+
+  private stubTestParams: ParamMap;
+  get testParams() {
+    return this.stubTestParams;
+  }
+  set testParams(params: {}) {
+    this.stubTestParams = new ParamMapStub(params);
+    this.paramsSubject.next(this.stubTestParams);
+  }
+}
+
+// A stub class that implements ParamMap.
+class ParamMapStub implements ParamMap {
+  constructor(private params: {[key: string]: string}) {}
+  has(name: string): boolean {
+    return this.params.hasOwnProperty(name);
+  }
+  get(name: string): string | null {
+    return this.params[name];
+  }
+
+  getAll(name: string): string[] {
+    return [this.params[name]];
+  }
+
+  get keys(): string[] {
+    let objKeys = [];
+    for(let key in this.params) {
+      objKeys.push(key);
+    }
+    return objKeys;
+  }
+}
+
+function setupQuestionMocks(httpMock: HttpTestingController,
+                            customClientJobKey: string) {
+  // Verify the call to load a question.
+  httpMock.expectOne('/api/work/' + customClientJobKey).flush([{
+    question_id: 'foo',
+    question: {id: 'bar', text: 'Hello world!'},
+    answers_per_question: 10,
+    answer_count: 5
+  }]);
+}
+
+function verifyQualityApiCalls(httpMock: HttpTestingController) {
+  // Verify job quality call.
+  httpMock.expectOne('/api/job_quality').flush({
+    toanswer_count: 50,
+    toanswer_mean_score: 2
+  });
+
+  // Verify worker quality call.
+  httpMock.expectOne((req: HttpRequest<any>): boolean => {
+    const workerQualityRequestUrlRegExp = /\/api\/quality\/?(\w+)?/;
+    const match = workerQualityRequestUrlRegExp.exec(req.urlWithParams);
+    return match !== null;
+  }).flush({
+    answer_count: 20,
+    mean_score: 1.5
+  });
+}
+
+let activatedRoute: ActivatedRouteStub;
+
+describe('IdentityCategoryHateJobComponent tests', () => {
+  beforeEach(async(() => {
+    activatedRoute = new ActivatedRouteStub();
+    activatedRoute.testParams = {};
+    TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        HttpClientModule,
+        HttpClientTestingModule,
+        FormsModule,
+        MatButtonModule,
+        MatCardModule,
+        MatCheckboxModule,
+        MatInputModule,
+        MatTabsModule,
+        ReactiveFormsModule,
+        RouterTestingModule.withRoutes(
+          [
+              {
+                path: 'identity_category_hate_job',
+                component: IdentityCategoryHateJobComponent
+              },
+              {
+                path: 'identity_category_hate_job/:customClientJobKey',
+                component: IdentityCategoryHateJobComponent
+              },
+          ]
+        )
+      ],
+      declarations: [
+        IdentityCategoryHateJobTestComponent,
+        IdentityCategoryHateJobComponent,
+      ],
+      providers: [
+        {provide: ActivatedRoute, useValue: activatedRoute},
+        CrowdSourceApiService,
+      ]
+    }).compileComponents();
+  }));
+
+  it('should create the component', async(() => {
+    const fixture = TestBed.createComponent(IdentityCategoryHateJobTestComponent);
+    const element = fixture.debugElement.componentInstance;
+    expect(element).toBeTruthy();
+
+    expect(fixture.nativeElement.textContent).not.toContain(
+      'Add your own template to extend the BaseJob component');
+  }));
+
+  it('Displays question', async(
+    (inject([HttpTestingController], (httpMock: HttpTestingController) => {
+    activatedRoute.testParams = {
+      customClientJobKey: 'testJobKey'
+    };
+
+    const fixture = TestBed.createComponent(IdentityCategoryHateJobTestComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Loading');
+
+    setupQuestionMocks(httpMock, 'testJobKey');
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Hello world!');
+  }))));
+
+  // TODO(rachelrosen): Maybe split this up into separate tests?
+  it('UI interaction for boolean labels tab', async(
+    (inject([HttpTestingController], (httpMock: HttpTestingController) => {
+    activatedRoute.testParams = {
+      customClientJobKey: 'testJobKey'
+    };
+
+    const fixture = TestBed.createComponent(IdentityCategoryHateJobTestComponent);
+    fixture.componentInstance.setTestIdentities(["cats", "dogs", "rabbits"]);
+    fixture.detectChanges();
+    setupQuestionMocks(httpMock, 'testJobKey');
+    fixture.detectChanges();
+
+    const jobComponent = fixture.componentInstance.identityJobComponent;
+
+    const tabs = fixture.debugElement.query(By.css('#tabGroup')).componentInstance;
+    expect(tabs.selectedIndex).toEqual(0);
+
+    // Checks that the question for all identities are displayed.
+    const questions = fixture.debugElement.queryAll(By.css('.identityQuestion'));
+    expect(questions.length).toEqual(3);
+    let hateQuestions = fixture.debugElement.queryAll(By.css('.hatefulQuestion'));
+    expect(hateQuestions.length).toEqual(0);
+
+    // Checks that questions about hate are displayed after clicking the
+    // checkboxes for the questions.
+    // Note: calling toggle() on the componentInstance does not update the
+    // template in the test, and calling click() on the nativeElement also has
+    // no effect. This is true when after calling whenStable().
+    // TODO(rachelrosen): Investigate why this happens.
+    questions[0].nativeElement.querySelector('input').click();
+    questions[2].nativeElement.querySelector('input').click();
+    fixture.detectChanges();
+
+    hateQuestions = fixture.debugElement.queryAll(By.css('.hatefulQuestion'));
+    expect(hateQuestions.length).toEqual(2);
+
+    expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+      {category: 'cats', markedAsCategory: true, hateful: false},
+      {category: 'dogs', markedAsCategory: false, hateful: false},
+      {category: 'rabbits', markedAsCategory: true, hateful: false}
+    ]);
+
+    // Check the hateful label box for the first group.
+    hateQuestions[0].nativeElement.querySelector('input').click();
+
+    expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+      {category: 'cats', markedAsCategory: true, hateful: true},
+      {category: 'dogs', markedAsCategory: false, hateful: false},
+      {category: 'rabbits', markedAsCategory: true, hateful: false}
+    ]);
+
+    // Check the hateful label box for the third group.
+    hateQuestions[1].nativeElement.querySelector('input').click();
+
+    expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+      {category: 'cats', markedAsCategory: true, hateful: true},
+      {category: 'dogs', markedAsCategory: false, hateful: false},
+      {category: 'rabbits', markedAsCategory: true, hateful: true}
+    ]);
+
+    // Uncheck one of the selected checkboxes, and check that the hateful
+    // question is hidden again and the hate value has been reset.
+    questions[2].nativeElement.querySelector('input').click();
+    fixture.detectChanges();
+    hateQuestions = fixture.debugElement.queryAll(By.css('.hatefulQuestion'));
+    expect(hateQuestions.length).toEqual(1);
+
+    expect(jobComponent.buildAnswer().identitiesWithLabels).toEqual([
+      {category: 'cats', markedAsCategory: true, hateful: true},
+      {category: 'dogs', markedAsCategory: false, hateful: false},
+      {category: 'rabbits', markedAsCategory: false, hateful: false}
+    ]);
+  }))));
+
+  // TODO(rachelrosen): Write this test.
+  xit('UI interaction for detailed labels tab', async(
+    (inject([HttpTestingController], (httpMock: HttpTestingController) => {
+  }))));
+});

--- a/api-service/webapp-demo/src/app/identity_category_hate_job.component.ts
+++ b/api-service/webapp-demo/src/app/identity_category_hate_job.component.ts
@@ -1,0 +1,59 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {ActivatedRoute, Params, ParamMap, Router} from '@angular/router';
+import 'rxjs/add/operator/switchMap';
+import { Observable } from 'rxjs/Observable';
+import {
+  CommentQuestion,
+  CrowdSourceApiService,
+  CrowdSourceAnswer,
+  JobQualitySummary,
+  WorkToDo,
+  WorkerQualitySummary
+} from './crowd_source_api.service';
+import {BaseJobComponent} from './base_job.component';
+
+interface IdentityCategoryHateJobCrowdSourceAnswer extends CrowdSourceAnswer {
+  identitiesWithLabels: IdentityCategoryAndHateLabels[];
+}
+
+interface IdentityCategoryAndHateLabels {
+  category: string;
+  markedAsCategory: boolean;
+  hateful: boolean;
+}
+
+// Constants for data collection
+const YES = 'Yes';
+const NO = 'No';
+
+@Component({
+  selector: 'identity-category-hate-job',
+  templateUrl: './identity_category_hate_job.component.html',
+  styleUrls: ['./identity_category_hate_job.component.css']
+})
+export class IdentityCategoryHateJobComponent extends BaseJobComponent {
+  @Input() routerPath = '/identity_category_hate_job';
+
+  identities: string[] = ['group1', 'group2'];
+  labels : {[key: string]: IdentityCategoryAndHateLabels } = {};
+
+  public buildAnswer(): IdentityCategoryHateJobCrowdSourceAnswer {
+    return Object.assign(
+      super.buildAnswer(),
+      {
+        identitiesWithLabels: Object.keys(this.labels).map(key=>this.labels[key]),
+      }
+    );
+  }
+
+  resetQuestionUI(): void {
+    this.labels = {};
+    for (let identity of this.identities) {
+      this.labels[identity] = {
+        category: identity,
+        markedAsCategory: false,
+        hateful: false
+      };
+    }
+  }
+}

--- a/api-service/webapp-demo/src/app/identity_category_hate_job.component.ts
+++ b/api-service/webapp-demo/src/app/identity_category_hate_job.component.ts
@@ -1,31 +1,32 @@
-import {Component, Input, OnInit} from '@angular/core';
-import {ActivatedRoute, Params, ParamMap, Router} from '@angular/router';
-import 'rxjs/add/operator/switchMap';
-import { Observable } from 'rxjs/Observable';
-import {
-  CommentQuestion,
-  CrowdSourceApiService,
-  CrowdSourceAnswer,
-  JobQualitySummary,
-  WorkToDo,
-  WorkerQualitySummary
-} from './crowd_source_api.service';
-import {BaseJobComponent} from './base_job.component';
+import {Component, Input } from '@angular/core';
+import { CrowdSourceAnswer } from './crowd_source_api.service';
+import { MatCheckbox, MatCheckboxChange } from '@angular/material';
+import { BaseJobComponent } from './base_job.component';
 
 interface IdentityCategoryHateJobCrowdSourceAnswer extends CrowdSourceAnswer {
-  identitiesWithLabels: IdentityCategoryAndHateLabels[];
+  identitiesWithLabels: IdentityCategoryAndHateBool[]|IdentityCategoryAndHateLabels[];
 }
 
-interface IdentityCategoryAndHateLabels {
+/** Identity hate answer with a boolean label for hateful. */
+interface IdentityCategoryAndHateBool {
   category: string;
   markedAsCategory: boolean;
   hateful: boolean;
 }
 
-// Constants for data collection
-const YES = 'Yes';
-const NO = 'No';
+/** Identity hate answer with a dictionary of hateful labels. */
+interface IdentityCategoryAndHateLabels {
+  category: string;
+  markedAsCategory: boolean;
+  hatefulLabels: {[label: string]: boolean};
+}
 
+/**
+ * Test UI component for an identity hate labeling job which provides two UI
+ * options in different tabs. One UI option presents a boolean checkbox for
+ * hateful per category, the other presents multiple checkboxes for different
+ * aspects of hate.
+ */
 @Component({
   selector: 'identity-category-hate-job',
   templateUrl: './identity_category_hate_job.component.html',
@@ -34,26 +35,90 @@ const NO = 'No';
 export class IdentityCategoryHateJobComponent extends BaseJobComponent {
   @Input() routerPath = '/identity_category_hate_job';
 
+  selectedTabIndex = 0;
+
   identities: string[] = ['group1', 'group2'];
-  labels : {[key: string]: IdentityCategoryAndHateLabels } = {};
+  detailedHateOptions = [
+    {
+      text: 'contain slurs, epithets, or profane language directed towards the identity group',
+      key: 'slurs'
+    },
+    {
+      text: 'threaten or incite violence towards the identity group',
+      key: 'violence',
+    },
+    {
+      text: 'make false accusations (such as conspiracy theories) against the identity group',
+      key: 'false_accusations',
+    },
+    {
+      text: 'otherwise insult or demean the identity group',
+      key: 'other_hate',
+    },
+  ];
+
+  booleanLabels : {[key: string]: IdentityCategoryAndHateBool } = {};
+  detailLabels : {[key: string]: IdentityCategoryAndHateLabels } = {};
 
   public buildAnswer(): IdentityCategoryHateJobCrowdSourceAnswer {
-    return Object.assign(
-      super.buildAnswer(),
-      {
-        identitiesWithLabels: Object.keys(this.labels).map(key=>this.labels[key]),
-      }
-    );
+    if (this.selectedTabIndex === 0) {
+      return Object.assign(
+        super.buildAnswer(),
+        {
+          identitiesWithLabels: Object.keys(this.booleanLabels).map(key=>this.booleanLabels[key]),
+        }
+      );
+    } else {
+      return Object.assign(
+        super.buildAnswer(),
+        {
+          identitiesWithLabels: Object.keys(this.detailLabels).map(key=>this.detailLabels[key]),
+        }
+      );
+    }
   }
 
   resetQuestionUI(): void {
-    this.labels = {};
+    this.booleanLabels = {};
+    this.detailLabels = {};
     for (let identity of this.identities) {
-      this.labels[identity] = {
+      this.booleanLabels[identity] = {
         category: identity,
         markedAsCategory: false,
-        hateful: false
+        hateful: false,
       };
+
+      this.detailLabels[identity] = {
+        category: identity,
+        markedAsCategory: false,
+        hatefulLabels: {},
+      };
+      for (let option of this.detailedHateOptions) {
+        this.detailLabels[identity].hatefulLabels[option.key] = false;
+      }
+    }
+  }
+
+  clearHateDetailLabelsIfNoneSelected(event: MatCheckboxChange, identity: string) {
+    if (event.checked) {
+      for (let option of this.detailedHateOptions) {
+        this.detailLabels[identity].hatefulLabels[option.key] = false;
+      }
+    }
+  }
+
+  clearNoneLabelIfHateDetailsSelected(event: MatCheckboxChange,
+                                      noneCheckbox: MatCheckbox) {
+    if (event.checked) {
+      noneCheckbox.checked = false;
+    }
+  }
+
+  clearHatefulLabelsIfCategoryDeselected(identity: string) {
+    if (!this.detailLabels[identity].markedAsCategory) {
+      for (let option of this.detailedHateOptions) {
+        this.detailLabels[identity].hatefulLabels[option.key] = false;
+      }
     }
   }
 }

--- a/api-service/webapp-demo/src/app/identity_category_hate_job.component.ts
+++ b/api-service/webapp-demo/src/app/identity_category_hate_job.component.ts
@@ -37,7 +37,7 @@ export class IdentityCategoryHateJobComponent extends BaseJobComponent {
 
   selectedTabIndex = 0;
 
-  identities: string[] = ['group1', 'group2'];
+  @Input() identities: string[] = ['group1', 'group2'];
   detailedHateOptions = [
     {
       text: 'contain slurs, epithets, or profane language directed towards the identity group',
@@ -81,6 +81,9 @@ export class IdentityCategoryHateJobComponent extends BaseJobComponent {
   resetQuestionUI(): void {
     this.booleanLabels = {};
     this.detailLabels = {};
+    if (!this.identities) {
+      return;
+    }
     for (let identity of this.identities) {
       this.booleanLabels[identity] = {
         category: identity,

--- a/api-service/webapp-demo/yarn.lock
+++ b/api-service/webapp-demo/yarn.lock
@@ -2022,6 +2022,10 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+hammerjs@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
+
 handle-thing@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-1.2.5.tgz#fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4"


### PR DESCRIPTION
The component has a tab layout with each tab containing different annotation schemes and UIs.

Currently it has two tabs, with the first tab having a binary annotation scheme (check the box if the comment is about the identity, check this other box if the comment is hateful towards that identity):

![Tab 1](https://user-images.githubusercontent.com/21343893/38260418-8be9eb5c-3735-11e8-9bcf-a119328d8f79.png)

In the second tab, instead of a binary "is this comment hateful for [identity]" box, it instead has a list of checkboxes for different types of content the comment could contain to make it hateful towards that identity.
![Tab 2](https://user-images.githubusercontent.com/21343893/38260429-901508a6-3735-11e8-9475-95583ca44de0.png)

To preview, go to http://localhost:4200/#/identity_category_hate_job/1k-demo-ptoxic